### PR TITLE
Allow file extensions to be passed to `accepts` prop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -116,6 +116,16 @@ class Files extends React.Component {
             }
           }
         }
+      } else {
+        for (let i = 0; i < accepts.length; i++) {
+          let accept = accepts[i];
+          if (accept.match(/\.[a-z0-9]*$/)) {
+            const ext = accept.substr(1);
+            if (file.extension && file.extension === ext) {
+              return true
+            }
+          }
+        }
       }
       this.onError({
         code: 1,


### PR DESCRIPTION
If attempt to identify file's MIME type failed or file.type was equal to empty string, there was an error. I have fixed validation so it's possible now to add file's extensions in accepts array (like '.docx').